### PR TITLE
Overhaul of Functionality, No Longer Relying on Modded SLmod Variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 ## Synopsis
 
-(SLmod Stats Cron) converts lua table to json object, sends to an arbitrary web-based API via POST request
+(SLmod Stats Cron) converts a LUA table into JSON object, & sends it to any web server via POST request
 
-### This app is meant to be deployed on every DCS + SLmod_S3 game server you want to post statistics for.
-If you plan on running this app alongside an S3 server, you will need valid authenticators (id, token) pair of values from the S3 server.<br/>
+**SLSC NOW WORKS SEAMLESSLY WITH STANDARD [SLMOD](https://github.com/mrSkortch/DCS-SLmod/tree/develop)**
+
+More technically, it finds your stats table, hashes it, compares it against the previous hash to see if the 2 tables are different.  If the hashes are different, it tries to POST the JSON to a web server.
+Easy personal configuration by editing config.js; Seamless integration with [S3](https://github.com/Bango1999/S3)
+
+### This app is meant to be deployed on every DCS + SLmod game server you want to post statistics for.
+If you plan on running this app alongside an S3 server, you will need to setup valid authenticators (id, token) pair of values from the S3 server.<br/>
 If you do not plan on running an S3 server, that's OK too!  SLSC is agnostic.  You can send the SLmod stats as a JSON object to any server you like that accepts POST requests.
 
+## Dependencies / Prerequisites
+
+- Git
+- [Node.js](https://nodejs.org/en/download/)
+- Be hosting a DCS mission using [SLmod](https://github.com/mrSkortch/DCS-SLmod/tree/develop)
+- ( Optional ) Create/have someone create/someone already created an [S3](https://github.com/Bango1999/S3) server ([See it in action](http://stats.229ahb.com:4000/))
+
 ## Usage
-
-Prereqs:
-- Be hosting a DCS mission using [SLmod_S3](https://github.com/Bango1999/SLmod_S3)
-- ( Optional ) Create/have someone create/someone already created an [S3 server](https://github.com/Bango1999/S3) ([See it in action](http://stats.229ahb.com:4000/))
-
 
 Edit global config variables in config.js<br />
 Then run the app:
@@ -25,36 +32,37 @@ Flags:
 
 WINDOWS ONLY EASE OF ACCESS:
 - you can run the app from any of the SLSC.bat files
+- you can update the app with Update_SLSC.bat
 - you can create shortcuts to SLSC.bat files and place them anywhere you want, and run from that
 
 ## Motivation
 
-I fly helicopters in a simulator with a unit called the 229th. The simulator is DCS, and the mod is SLmod, which is really neat because it logs game statistics.
+I fly helicopter simulations with a unit called the 229th. The simulator is DCS, and the mod is SLmod, which is really neat because it logs game statistics.
 
-The idea was, let's get that data from SLmod and make it [web-facing](http://stats.229ahb.com:4000/) so people can look anytime, say, what their flight hours are for a particular server.
+The idea was, let's get that data from SLmod and make it web-facing so people can look anytime, say, what their flight hours are for a particular server.
 
 This could help IP's see logged hours, or just let people go and see their kills or deaths.
 
 ## Installation
 
-1) Install node.js (full installer .msi file for Windows)<br />
-   https://nodejs.org/en/download/<br/>
-   or in linux (apt-get/yum install nodejs)
+1) From a terminal, `git clone https://github.com/Bango1999/SLSC.git`
 
-2) from a terminal, git clone https://github.com/Bango1999/SLSC.git
+2) Windows users can then click and run 'Update_SLSC.bat' from the new SLSC folder
+   Otherwise, run the command `npm update` from inside the SLSC folder
 
-3a) If Windows, go to the project folder you just cloned in file explorer and run the file Update_SLSC.bat<br/>
-3b) If not Windows, stay inside the terminal and run 'npm update'
+3) Edit config.js in a text editor<br />
+   You will see a bunch of 'const' variables<br />
+   Set their values according to your personal wants and needs. Defaults should mostly be fine :)
 
-6) Edit config.js in a text editor.<br />
-   At the top of the file, you will see a bunch of 'const' variables.<br />
-   Set them according to your personal server/setup. Defaults should mostly be fine.
+4) Windows users can then click and run 'SLSC_Debug.bat'
+   Otherwise, run the server with the command `node cron.js -v` from the SLSC folder
 
-7a) If Windows, run the file SLSC_Debug.bat
-7b) If not Windows, test by running 'node cron.js -v' in the cmd prompt window<br />
-    By default it will run once a minute, so be patient while you wait for it to log its first attempt.<br />
+5) Similarly to steps 1-4, install & configure your [S3](https://github.com/Bango1999/S3) server
+
+6)  By default it will check for new stats once a minute, so be patient while you wait for it to log its first attempt.<br />
     When you start seeing logs, use them to troubleshoot or confirm everything is working.
-    ctrl + c to terminate the node application running in the cmd window.
+    ctrl + c to terminate the node application running in the command prompt window.
+
 ## License
 
 MIT

--- a/SLSC.bat
+++ b/SLSC.bat
@@ -1,1 +1,2 @@
 node cron.js -d
+pause

--- a/SLSC_Debug.bat
+++ b/SLSC_Debug.bat
@@ -1,1 +1,2 @@
 node cron.js -v
+pause

--- a/SLSC_Silent.bat
+++ b/SLSC_Silent.bat
@@ -1,1 +1,2 @@
 node cron.js -s
+pause

--- a/config.js
+++ b/config.js
@@ -5,13 +5,15 @@
 
 
 
- // ---------------------------
+// ---------------------------
+// SERVER NAME
 // Default: 'Server Running SLmod'
 // what is the server called?
 // ---------------------------
  const serverName = 'Server Running SLmod';
 
 // ---------------------------
+// SERVER ID, SERVER TOKEN
 // Default: 0, 'token_for_server_0'
 // these 2 variables should be given to you by the person hosting the stats server
 // Only necessary to configure if you are POSTing to an S3 server
@@ -21,54 +23,74 @@
 
 
 // ---------------------------
-// Default: http://localhost:4000/api/dcs/slmod/update
-// The link to your S3 server + and the default S3 API route
+// S3 SERVER POST PATH
+// Default: 'http://localhost:4000/api/dcs/slmod/update'
+// The link to your S3 server, + the default S3 API route
+//   If you ARE running an S3 server, only edit serverURL to match the URL of your S3 server
 //   If you are NOT running an S3 server, you will need to edit the route in postPath to fit the route for your own API
-//   If you ARE running an S3 server, only edit serverURL to match where you are hosting your S3 server
 // ---------------------------
 const serverURL = 'http://localhost:4000';
   const postPath = serverURL + '/api/dcs/slmod/update';
 
 
 // ---------------------------
-// Default: 'C:\\Users\\dcs\\Saved Games\\DCS\\Slmod\\slmod_official_lua_stats.lua';
+// STATS LOCATION & FILENAME
+// Default: 'C:\\Users\\Huckleberry\\Saved Games\\DCS\\Slmod\\SlmodStats.lua'
 // The Directory + Filename of the lua stats file for node
-//   You will likely wish to edit windowsUsername
+//   You will likely need to edit windowsUsername
 //   If you are running a DCS other than stable, edit DCS folder name in dcsVersion
 //----------------------------
-const windowsUsername = 'dcs';
-const dcsVersion = 'DCS';
-  const statsDir = 'C:\\Users\\'+ windowsUsername +'\\Saved Games\\'+ dcsVersion +'\\Slmod\\slmod_official_lua_stats.lua';
+  const windowsUsername = 'Bango';
+  const dcsVersion = 'DCS'; // if youre in beta, it would be 'DCS.openbeta', etc
+const statsPath = 'C:\\Users\\'+ windowsUsername +'\\Saved Games\\'+ dcsVersion +'\\Slmod\\SlmodStats.lua';
 
 
 // ---------------------------
+// UPDATE FREQUENCY
 // Default: '* * * * *'
-// Default: (AKA, once every minute)
 // How often should it check for new stats?
-//   https://code.tutsplus.com/tutorials/scheduling-tasks-with-cron-jobs--net-8800
+// For testing, every minute is fine.  Otherwise, 3x/hr is plenty
+// Format: [minute] [hour] [day-of-month] [month] [day-of-week]
+// Examples: ('*' = all)
+//    '* * * * *'         <- Run every minute
+//    '*/5 * * * *'       <- Run every 5 minutes
+//    '0,20,40 * * * *'   <- Run 3 times per hour, at minutes 0, 20, and 40
+//    '30 2 * * *'        <- Run once a day at 2:30 AM
+// https://code.tutsplus.com/tutorials/scheduling-tasks-with-cron-jobs--net-8800
 // ---------------------------
 const schedule = '* * * * *';
 
 
 // ---------------------------
+// BACKUP AS JSON?
 // Default: false
 // Make true if you want to Backup the latest sent JSON data
 // ---------------------------
-const writeJson = false;
+const writeJson = true;
 
 
 // ---------------------------
+// JSON LOCATION & FILENAME
 // Default: process.cwd() + '\\json\\stats.json'
 // Or specify a specific Directory + Filename to Backup the latest sent JSON data to
 // ---------------------------
-const jsonDir = process.cwd() + '\\json\\stats.json';
+const jsonPath = process.cwd() + '\\json\\stats.json';
+
+// ---------------------------
+// HASH LOCATION & FILENAME
+// Default: process.cwd() + '\\json\\hash.txt'
+// Probably good to keep this wherever the backup JSON is being stored
+// Unlike the JSON backup, the hash file is mandatory.
+// ---------------------------
+const hashPath = process.cwd() + '\\json\\hash.txt';
 
 
 // ---------------------------
+// STATS VARIABLE NAME
 // Default: 'stats'
 // The Name of the Table in the lua file to parse into JSON
-// This is the default value for all of SLmod, so best leave it alone
-//  unless you know something I don't
+// This is the default value in SLmod, so leave it alone...
+// unless at some point, SLmod is updated, and 'stats' is no longer the key name
 // ---------------------------
 const statsVar = 'stats';
 
@@ -79,14 +101,15 @@ const statsVar = 'stats';
 
 
 module.exports = {
-  getJsonDir: function() { return jsonDir },
-  getSchedule: function() { return schedule },
+  getJsonPath: function() { return jsonPath },
+  getHashPath: function() { return hashPath },
   getPostPath: function() { return postPath },
-  getStatsDir: function() { return statsDir },
+  getSchedule: function() { return schedule },
   getStatsVar: function() { return statsVar },
   getServerId: function() { return serverId },
+  getStatsPath: function() { return statsPath },
   getWriteJson: function() { return writeJson },
   getServerName: function() { return serverName },
-  getServerToken: function() { return serverToken }
+  getServerToken: function() { return serverToken },
 };
 // By: Huckleberry

--- a/config.js
+++ b/config.js
@@ -40,7 +40,7 @@ const serverURL = 'http://localhost:4000';
 //   You will likely need to edit windowsUsername
 //   If you are running a DCS other than stable, edit DCS folder name in dcsVersion
 //----------------------------
-  const windowsUsername = 'Bango';
+  const windowsUsername = 'Huckleberry';
   const dcsVersion = 'DCS'; // if youre in beta, it would be 'DCS.openbeta', etc
 const statsPath = 'C:\\Users\\'+ windowsUsername +'\\Saved Games\\'+ dcsVersion +'\\Slmod\\SlmodStats.lua';
 

--- a/config.js
+++ b/config.js
@@ -66,7 +66,7 @@ const schedule = '* * * * *';
 // Default: false
 // Make true if you want to Backup the latest sent JSON data
 // ---------------------------
-const writeJson = true;
+const writeJson = false;
 
 
 // ---------------------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SLSC",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "(SLmod Stats Cron) converts lua table to json object, sends to a web-based API via POST request",
   "main": "cron.js",
   "scripts": {
@@ -12,6 +12,7 @@
     "lua2json": "^1.1.2",
     "node-cron": "^1.1.3",
     "process": "^0.11.9",
-    "request": "^2.81.0"
+    "request": "^2.81.0",
+    "crypto": "latest"
   }
 }


### PR DESCRIPTION
Slmod author is not responding to my pull request, so this is a workaround on my end, so people don't have to use my version of SLmod to use SLSC, and S3.

This diff sort of accepts the fact we will never have realtime updates, and instead bites the bullet and parses the stats table into JSON with every cron recurrence.

While its true that it will be more process intensive overall, true CPU cost is negligible.  I have not deeply tested RAM usage, but on my dataset, it runs so fast that I can't even track its change in resource monitor.